### PR TITLE
Adding Commandline option to set the location of the settings.ini file

### DIFF
--- a/README
+++ b/README
@@ -8,6 +8,8 @@ Installation
   depending on which platform you are using this program, e.g.:
   * Linux: $HOME/.config/radiorec/settings.ini or
   * Windows: %LOCALAPPDATA%/radiorec/settings.ini
+  or use the commandline option '-s' to specify the location of the
+  settings.ini file.
 - Adjust the settings to your needs. You can happily add more radio stations
   to the STATIONS section.
   !!! Check at least the the target_dir !!!
@@ -54,8 +56,8 @@ how to schedule your recording tasks.
 Known problems
 ==============
 The Windows command line (cmd and powershell) still has problems with UTF-8.
-Using the --verbose option might cause the script to crash with an 
-UnicodeEncodeError. If you want to avoid the crash, you have to do both, 
+Using the --verbose option might cause the script to crash with an
+UnicodeEncodeError. If you want to avoid the crash, you have to do both,
 change the command line codepage and the font. For example, doing a
 "chcp 65001" and changing the font to "Lucidia Console" should help.
 

--- a/radiorec.py
+++ b/radiorec.py
@@ -43,9 +43,11 @@ def check_duration(value):
         return value
 
 
-def read_settings():
+def read_settings(args):
     settings_base_dir = ''
-    if sys.platform.startswith('linux'):
+    if args.settings:
+        settings_base_dir = args.settings
+    elif sys.platform.startswith('linux'):
         settings_base_dir = os.getenv(
             'HOME') + os.sep + '.config' + os.sep + 'radiorec'
     elif sys.platform == 'win32':
@@ -93,7 +95,7 @@ def record_worker(stoprec, streamurl, target_dir, args):
 
 
 def record(args):
-    settings = read_settings()
+    settings = read_settings(args)
     streamurl = ''
     global verboseprint
     verboseprint = print if args.verbose else lambda *a, **k: None
@@ -126,7 +128,7 @@ def record(args):
 
 
 def list(args):
-    settings = read_settings()
+    settings = read_settings(args)
     for key in sorted(settings['STATIONS']):
         print(key)
 
@@ -150,9 +152,15 @@ def main():
         help="Public write permissions (Linux only)")
     parser_record.add_argument(
         '-v', '--verbose', action='store_true', help="Verbose output")
+    parser_record.add_argument(
+        '-s', '--settings', nargs='?', type=str,
+        help="specify alternative location for settings.ini")
     parser_record.set_defaults(func=record)
     parser_list = subparsers.add_parser('list', help='List all known stations')
     parser_list.set_defaults(func=list)
+    parser_list.add_argument(
+        '-s', '--settings', nargs='?', type=str,
+        help="specify alternative location for settings.ini")
 
     if not len(sys.argv) > 1:
         print('Error: No argument specified.\n')


### PR DESCRIPTION
Adding the option '-s' or '--settings' to set the location of the settings.ini file. It is of use when running the script on linux as a user without a homefolder. 